### PR TITLE
BREAKING: make dl/stream token also depend on user's password

### DIFF
--- a/home_stream/helpers.py
+++ b/home_stream/helpers.py
@@ -118,6 +118,12 @@ def get_stream_token(username: str, chars: int = 16) -> str:
     return hmac.new(secret.encode(), token_input.encode(), hashlib.sha256).hexdigest()[:chars]
 
 
+def compute_session_signature(username, password_hash, secret):
+    """Compute a session signature based on username and password hash."""
+    data = f"{username}:{password_hash}"
+    return hmac.new(secret.encode(), data.encode(), hashlib.sha256).hexdigest()
+
+
 def truncate_secret(secret: str, chars: int = 8) -> str:
     """Truncate the secret key to a specified length"""
     if len(secret) > chars:

--- a/home_stream/helpers.py
+++ b/home_stream/helpers.py
@@ -106,9 +106,16 @@ def validate_user(username, password):
 
 
 def get_stream_token(username: str, chars: int = 16) -> str:
-    """Generate a n-chars permanent token for streaming based on username and secret key."""
+    """Generate a permanent token for streaming based on username, password hash, and secret key"""
     secret = current_app.config["STREAM_SECRET"]
-    return hmac.new(secret.encode(), username.encode(), hashlib.sha256).hexdigest()[:chars]
+    users = current_app.config.get("USERS", {})
+
+    password_hash = users.get(username)
+    if not password_hash:
+        raise ValueError(f"User '{username}' not found when generating stream token.")
+
+    token_input = f"{username}:{password_hash}"
+    return hmac.new(secret.encode(), token_input.encode(), hashlib.sha256).hexdigest()[:chars]
 
 
 def truncate_secret(secret: str, chars: int = 8) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ import pytest
 import yaml
 
 from home_stream.app import create_app
-from home_stream.helpers import get_stream_token, slugify
+from home_stream.helpers import compute_session_signature, get_stream_token, slugify
 
 MINIMAL_MP3 = bytes.fromhex(
     "494433030000000021764c414d4533322e39372e39000000"  # ID3 header for metadata
@@ -55,6 +55,16 @@ def fixture_app(config_file):
 def fixture_client(app):
     """Create a test client for the app"""
     return app.test_client()
+
+
+def login_session(sess, app, username="testuser"):
+    """Helper to simulate a logged-in user inside a test session."""
+    with app.app_context():
+        users = app.config["USERS"]
+        secret = app.config["STREAM_SECRET"]
+
+        sess["username"] = username
+        sess["auth_signature"] = compute_session_signature(username, users[username], secret)
 
 
 @pytest.fixture(name="stream_token")

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -236,3 +236,26 @@ def test_prepare_path_context_generates_breadcrumbs():
         {"name": "Shows", "slug": "Shows"},
         {"name": "Battlestar Galactica", "slug": "Shows/Battlestar_Galactica"},
     ]
+
+def test_stream_token_changes_when_password_changes(app):
+    """Ensure that changing the user's password results in a new stream token"""
+    with app.app_context():
+        users = current_app.config["USERS"]
+
+        # Original token
+        original_token = get_stream_token("testuser")
+
+        # Simulate password change
+        users["testuser"] = "new_fake_password_hash"
+
+        # New token after password change
+        new_token = get_stream_token("testuser")
+
+        assert original_token != new_token, "Stream token did not change after password update"
+
+
+def test_get_stream_token_raises_for_missing_user(app):
+    """Ensure get_stream_token raises ValueError if user does not exist"""
+    with app.app_context():
+        with pytest.raises(ValueError, match="User 'unknownuser' not found"):
+            get_stream_token("unknownuser")


### PR DESCRIPTION
This way, a user who changed their password will invalidate the old links, disabling use of old, perhaps leaked URLs.

Also ensures that a password change invalidates the session.