### PR TITLE
ci: restrict some workflows to only run upstream

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -17,6 +17,7 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    if: github.repository == 'mxmehl/home-stream'
     steps:
       - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token

--- a/.github/workflows/release-vulnerabilities.yaml
+++ b/.github/workflows/release-vulnerabilities.yaml
@@ -15,5 +15,6 @@ permissions:
 jobs:
   osv-check:
     runs-on: ubuntu-latest
+    if: github.repository == 'mxmehl/home-stream'
     steps:
       - uses: mxmehl/latest-release-vulnerability-status@71769afeefe3a1f2fae289a41b0983961317c557 # v1.2.1


### PR DESCRIPTION
Adds `if: github.repository == '...'` condition to release-please and release-vulnerabilities workflows so they only run in the upstream repository, not in forks.