### PR TITLE
feat: show Kodi .nfo metadata in browse view

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A web-based browser and streaming interface for local media files. Supports in-b
 ## Features
 
 - Browse local folders and media files
+- Show titles and metadata from Kodi-style `.nfo` files in the browse view (toggleable)
 - Secure user login
 - In-browser audio/video player (if supported by your browser)
 - HTTP Basic Auth fallback for external players (VLC, mpv, etc.) using authenticated links

--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -37,6 +37,10 @@ protocol: https
 # Optional: internal URI namespace used for X-Accel-Redirect (xaccel only).
 # Must match the `internal` location block in your nginx config. Default: /_protected
 # download_internal_prefix: /_protected
+# Optional: show metadata from Kodi-style .nfo sidecar files (title, year, rating, plot)
+# in the browse view. Reads "<name>.nfo" next to each media file and a "tvshow.nfo" in
+# the folder. Sorting still happens on file name. Default: true
+# show_nfo_metadata: true
 # Optional: Modified rate limits following https://flask-limiter.readthedocs.io/en/stable/configuration.html#rate-limit-string-notation
 # rate_limit_default: 25 per 5 minutes
 # rate_limit_login: 2 per 10 seconds

--- a/home_stream/app.py
+++ b/home_stream/app.py
@@ -43,6 +43,7 @@ from home_stream.helpers import (
     get_version_info,
     list_folder_entries_with_stream_urls,
     load_config,
+    read_tvshow_metadata,
     truncate_secret,
     validate_user,
 )
@@ -191,6 +192,11 @@ def init_routes(app: Flask, limiter: Limiter) -> None:  # noqa: C901, PLR0915
             rel_path=subpath,
         )
 
+        # Folder-level metadata from a tvshow.nfo, if present and enabled
+        show_metadata = (
+            read_tvshow_metadata(real_path) if app.config.get("SHOW_NFO_METADATA") else {}
+        )
+
         return render_template(
             "browse.html",
             slugified_path=path_context["slugified_path"],
@@ -199,6 +205,7 @@ def init_routes(app: Flask, limiter: Limiter) -> None:  # noqa: C901, PLR0915
             folders=folders,
             files=files,
             playlist_stream_url=playlist_stream_url,
+            show_metadata=show_metadata,
         )
 
     @app.route("/play/<path:subpath>")  # noqa: RET503
@@ -233,7 +240,9 @@ def init_routes(app: Flask, limiter: Limiter) -> None:  # noqa: C901, PLR0915
                 username=username,
             )
             mediatype = (
-                "audio" if all(file_type(f.get("name", "")) == "audio" for f in files) else "video"
+                "audio"
+                if all(file_type(str(f.get("name", ""))) == "audio" for f in files)
+                else "video"
             )
 
             return render_template(

--- a/home_stream/helpers.py
+++ b/home_stream/helpers.py
@@ -13,6 +13,7 @@ import os
 import re
 import subprocess
 from urllib.parse import quote
+from xml.etree import ElementTree as ET
 
 import yaml
 from bcrypt import checkpw
@@ -30,6 +31,11 @@ REQUIRED_CONFIG_KEYS = (
 )
 
 VALID_DOWNLOAD_METHODS = frozenset({"direct", "xaccel", "xsendfile"})
+
+# Cap .nfo size before parsing as a cheap DoS guard (these files are tiny in practice).
+NFO_MAX_BYTES = 1024 * 1024
+# Fields extracted from .nfo files, in display order.
+NFO_FIELDS = ("title", "year", "rating", "plot")
 
 
 def load_config(app: Flask, filename: str) -> None:
@@ -81,6 +87,9 @@ def load_config(app: Flask, filename: str) -> None:
     app.config["DOWNLOAD_INTERNAL_PREFIX"] = str(
         app.config.get("DOWNLOAD_INTERNAL_PREFIX", "/_protected")
     ).rstrip("/")
+
+    # Show metadata from Kodi-style .nfo sidecar files in the browse view (default on).
+    app.config["SHOW_NFO_METADATA"] = bool(app.config.get("SHOW_NFO_METADATA", True))
 
     # Print the loaded config in DEBUG mode
     app.logger.debug(app.config)
@@ -254,7 +263,7 @@ def extract_path_components(subpath: str) -> tuple[list[str], str, dict]:
 
 def list_folder_entries_with_stream_urls(
     real_path: str, slug_parts: list[str], username: str
-) -> tuple[list[dict[str, str]], list[dict[str, str]]]:
+) -> tuple[list[dict[str, str]], list[dict[str, object]]]:
     """List directories and media files in a folder with slugified paths.
 
     This function scans the given directory, filters out hidden folders,
@@ -273,7 +282,7 @@ def list_folder_entries_with_stream_urls(
             - list of dicts (name (file), slug_path, stream_url)
     """
     folders: list[dict[str, str]] = []
-    files: list[dict[str, str]] = []
+    files: list[dict[str, object]] = []
 
     # Loop through all entries in the directory
     for dir_element in os.listdir(real_path):
@@ -291,17 +300,22 @@ def list_folder_entries_with_stream_urls(
             if ext in current_app.config["MEDIA_EXTENSIONS"]:
                 file_slug_path = "/".join([*slug_parts, entry_slug])
                 stream_url = build_stream_url(username, get_stream_token(username), file_slug_path)
-                files.append(
-                    {
-                        "name": sanitize_filename(dir_element),
-                        "slug_path": file_slug_path,
-                        "stream_url": stream_url,
-                    }
-                )
+                entry: dict[str, object] = {
+                    "name": sanitize_filename(dir_element),
+                    "slug_path": file_slug_path,
+                    "stream_url": stream_url,
+                }
+                # one .nfo open per media file per view; ceiling is O(files) filesystem stats on a
+                # folder render. Upgrade path: cache by path+mtime.
+                if current_app.config.get("SHOW_NFO_METADATA"):
+                    metadata = read_nfo_metadata(full)
+                    if metadata:
+                        entry["metadata"] = metadata
+                files.append(entry)
 
     # Sort entries alphabetically by name (case-insensitive)
     folders.sort(key=lambda x: x["name"].lower())
-    files.sort(key=lambda x: x["name"].lower())
+    files.sort(key=lambda x: str(x["name"]).lower())
 
     return folders, files
 
@@ -385,7 +399,7 @@ def build_stream_url(username: str, token: str, rel_path: str) -> str:
     return f"{protocol}://{host}/dl-token/{quote(username)}/{token}/{quote(rel_path)}"
 
 
-def build_playlist_content(playlist_name: str, files: list[dict[str, str]]) -> str:
+def build_playlist_content(playlist_name: str, files: list[dict[str, object]]) -> str:
     """Build a playlist content string for M3U8 format."""
     playlist_lines = ["#EXTM3U"]
     playlist_lines.append(f"#PLAYLIST: {playlist_name}")
@@ -394,7 +408,7 @@ def build_playlist_content(playlist_name: str, files: list[dict[str, str]]) -> s
             # TODO: Add duration of file
             f"#EXTINF:-1,{file.get('name', '')}"  # NOTE: -1 means unknown duration
         )
-        playlist_lines.append(file.get("stream_url", ""))
+        playlist_lines.append(str(file.get("stream_url", "")))
     return "\n".join(playlist_lines)
 
 
@@ -441,3 +455,54 @@ def _content_disposition(filename: str) -> str:
     """Build a Content-Disposition header safe for non-ASCII filenames (RFC 5987/6266)."""
     ascii_fallback = filename.encode("ascii", "replace").decode("ascii").replace('"', "")
     return f"attachment; filename=\"{ascii_fallback}\"; filename*=UTF-8''{quote(filename)}"
+
+
+def _parse_nfo(nfo_path: str) -> dict[str, str]:
+    """Safely parse a Kodi .nfo file and return selected fields as a dict.
+
+    Returns an empty dict on any problem (missing file, too large, malformed XML, or a hostile
+    document) so callers never have to handle errors.
+
+    stdlib xml.etree is used without a hardened parser. The ceiling is XML-bomb/XXE resistance: we
+    mitigate by capping size and refusing any document that declares a DOCTYPE/ENTITY (legitimate
+    tinyMediaManager .nfo files never do). Upgrade path: swap in a maintained hardened parser if
+    untrusted .nfo ever enter scope.
+    """
+    try:
+        if os.path.getsize(nfo_path) > NFO_MAX_BYTES:
+            return {}
+        with open(nfo_path, encoding="utf-8", errors="replace") as f:
+            text = f.read()
+    except OSError:
+        return {}
+
+    # Reject entity/DOCTYPE declarations outright (billion-laughs / XXE vectors).
+    lowered = text.lower()
+    if "<!doctype" in lowered or "<!entity" in lowered:
+        return {}
+
+    try:
+        root = ET.fromstring(text)  # noqa: S314 (guarded above; stdlib parser)
+    except ET.ParseError:
+        return {}
+
+    metadata: dict[str, str] = {}
+    for field in NFO_FIELDS:
+        element = root.find(field)
+        value = (element.text or "").strip() if element is not None else ""
+        # Drop empty values and placeholder zero ratings/years.
+        if not value or (field in ("rating", "year") and value in ("0", "0.0")):
+            continue
+        metadata[field] = value
+    return metadata
+
+
+def read_nfo_metadata(media_real_path: str) -> dict[str, str]:
+    """Read metadata from a media file's sibling .nfo (same name, .nfo extension)."""
+    nfo_path = os.path.splitext(media_real_path)[0] + ".nfo"
+    return _parse_nfo(nfo_path)
+
+
+def read_tvshow_metadata(folder_real_path: str) -> dict[str, str]:
+    """Read metadata from a folder's tvshow.nfo, if present."""
+    return _parse_nfo(os.path.join(folder_real_path, "tvshow.nfo"))

--- a/home_stream/helpers.py
+++ b/home_stream/helpers.py
@@ -494,6 +494,17 @@ def _parse_nfo(nfo_path: str) -> dict[str, str]:
         if not value or (field in ("rating", "year") and value in ("0", "0.0")):
             continue
         metadata[field] = value
+
+    # Build an SxxExx marker from the <season>/<episode> tags, if both are present.
+    # Season 0 is valid (Kodi uses it for specials), so only non-negative ints qualify;
+    # the -1 placeholders Kodi writes elsewhere are ignored.
+    season = (root.findtext("season") or "").strip()
+    episode = (root.findtext("episode") or "").strip()
+    if season.lstrip("-").isdigit() and episode.lstrip("-").isdigit():
+        s, e = int(season), int(episode)
+        if s >= 0 and e >= 0:
+            metadata["episode_marker"] = f"S{s:02d}E{e:02d}"
+
     return metadata
 
 

--- a/home_stream/helpers.py
+++ b/home_stream/helpers.py
@@ -495,17 +495,49 @@ def _parse_nfo(nfo_path: str) -> dict[str, str]:
             continue
         metadata[field] = value
 
-    # Build an SxxExx marker from the <season>/<episode> tags, if both are present.
-    # Season 0 is valid (Kodi uses it for specials), so only non-negative ints qualify;
-    # the -1 placeholders Kodi writes elsewhere are ignored.
+    # Movies use a nested <ratings><rating><value>..</value></rating></ratings> block instead
+    # of the flat <rating> tag. Fall back to it, preferring the default="true" rating.
+    if "rating" not in metadata:
+        rating = _extract_nested_rating(root)
+        if rating:
+            metadata["rating"] = rating
+
+    marker = _extract_episode_marker(root)
+    if marker:
+        metadata["episode_marker"] = marker
+
+    return metadata
+
+
+def _extract_episode_marker(root: ET.Element) -> str:
+    """Return an SxxExx marker from <season>/<episode>, or '' if not a valid episode.
+
+    Season 0 is valid (Kodi uses it for specials), so only non-negative ints qualify;
+    the -1 placeholders Kodi writes elsewhere are ignored.
+    """
     season = (root.findtext("season") or "").strip()
     episode = (root.findtext("episode") or "").strip()
     if season.lstrip("-").isdigit() and episode.lstrip("-").isdigit():
         s, e = int(season), int(episode)
         if s >= 0 and e >= 0:
-            metadata["episode_marker"] = f"S{s:02d}E{e:02d}"
+            return f"S{s:02d}E{e:02d}"
+    return ""
 
-    return metadata
+
+def _extract_nested_rating(root: ET.Element) -> str:
+    """Return the rating value from a <ratings> block, preferring default="true".
+
+    Returns an empty string if no usable (non-zero) rating is found.
+    """
+    ratings = root.findall("ratings/rating")
+    # Prefer the rating marked as default, otherwise take the first.
+    chosen = next((r for r in ratings if r.get("default") == "true"), None)
+    if chosen is None and ratings:
+        chosen = ratings[0]
+    if chosen is None:
+        return ""
+    value = (chosen.findtext("value") or "").strip()
+    return "" if value in ("", "0", "0.0") else value
 
 
 def read_nfo_metadata(media_real_path: str) -> dict[str, str]:

--- a/home_stream/static/style.css
+++ b/home_stream/static/style.css
@@ -33,34 +33,20 @@ ul.files li {
   color: var(--pico-muted-color);
 }
 
-/* Collapsible plot: the muted metadata line doubles as the <summary>,
-   so nothing is added above it and the row keeps its height when collapsed. */
+/* Collapsible plot: the muted metadata line doubles as the <summary>.
+   We reuse Pico's built-in <details> chevron (which already rotates when open)
+   and only retarget Pico's accordion colour variables to the muted colour,
+   rather than overriding its rules by specificity. */
 .file-details {
   margin: 0;
+  --pico-accordion-close-summary-color: var(--pico-muted-color);
+  --pico-accordion-open-summary-color: var(--pico-muted-color);
+  --pico-accordion-active-summary-color: var(--pico-muted-color);
 }
 
 .file-details > summary {
+  display: inline-block;     /* shrink to content so the chevron sits by the text */
   font-size: 0.85rem;
-  color: var(--pico-muted-color);
-  cursor: pointer;
-  list-style: none;          /* hide the default disclosure triangle */
-  display: inline-block;     /* keep the line compact, not full-width */
-}
-
-.file-details > summary::-webkit-details-marker {
-  display: none;             /* hide default marker in WebKit/Blink */
-}
-
-/* Subtle caret affordance that rotates when expanded */
-.file-details > summary::after {
-  content: " \25b8";          /* ▸ */
-  display: inline-block;
-  transition: transform 0.15s ease;
-  color: var(--pico-muted-color);
-}
-
-.file-details[open] > summary::after {
-  transform: rotate(90deg);
 }
 
 /* The expanded plot (reusable area for more metadata later) */
@@ -77,24 +63,14 @@ ul.files li {
   cursor: default;
 }
 
+details.show-meta {
+  --pico-accordion-close-summary-color: var(--pico-muted-color);
+  --pico-accordion-open-summary-color: var(--pico-muted-color);
+  --pico-accordion-active-summary-color: var(--pico-muted-color);
+}
+
 details.show-meta > summary {
-  cursor: pointer;
-  list-style: none;
   display: inline-block;
-}
-
-details.show-meta > summary::-webkit-details-marker {
-  display: none;
-}
-
-details.show-meta > summary::after {
-  content: " \25b8";
-  display: inline-block;
-  transition: transform 0.15s ease;
-}
-
-details.show-meta[open] > summary::after {
-  transform: rotate(90deg);
 }
 
 audio,

--- a/home_stream/static/style.css
+++ b/home_stream/static/style.css
@@ -21,12 +21,16 @@ ul.files li {
   padding: 0.2rem 0;
 }
 
-/* Secondary metadata line under a file row (from .nfo sidecars) */
-.file-meta {
+/* Title from .nfo shown as the primary line above the filename */
+.file-title {
   display: block;
+  cursor: default;
+}
+
+/* Filename demoted to a muted reference line when a title is shown */
+.file-name {
   font-size: 0.85rem;
   color: var(--pico-muted-color);
-  cursor: default;
 }
 
 /* Folder-level show metadata header (from tvshow.nfo) */

--- a/home_stream/static/style.css
+++ b/home_stream/static/style.css
@@ -33,10 +33,68 @@ ul.files li {
   color: var(--pico-muted-color);
 }
 
+/* Collapsible plot: the muted metadata line doubles as the <summary>,
+   so nothing is added above it and the row keeps its height when collapsed. */
+.file-details {
+  margin: 0;
+}
+
+.file-details > summary {
+  font-size: 0.85rem;
+  color: var(--pico-muted-color);
+  cursor: pointer;
+  list-style: none;          /* hide the default disclosure triangle */
+  display: inline-block;     /* keep the line compact, not full-width */
+}
+
+.file-details > summary::-webkit-details-marker {
+  display: none;             /* hide default marker in WebKit/Blink */
+}
+
+/* Subtle caret affordance that rotates when expanded */
+.file-details > summary::after {
+  content: " \25b8";          /* ▸ */
+  display: inline-block;
+  transition: transform 0.15s ease;
+  color: var(--pico-muted-color);
+}
+
+.file-details[open] > summary::after {
+  transform: rotate(90deg);
+}
+
+/* The expanded plot (reusable area for more metadata later) */
+.file-plot {
+  margin: 0.3rem 0 0.2rem;
+  font-size: 0.9rem;
+  max-width: 60ch;
+  white-space: pre-line;     /* preserve paragraph breaks from .nfo plots */
+}
+
 /* Folder-level show metadata header (from tvshow.nfo) */
 .show-meta {
   color: var(--pico-muted-color);
   cursor: default;
+}
+
+details.show-meta > summary {
+  cursor: pointer;
+  list-style: none;
+  display: inline-block;
+}
+
+details.show-meta > summary::-webkit-details-marker {
+  display: none;
+}
+
+details.show-meta > summary::after {
+  content: " \25b8";
+  display: inline-block;
+  transition: transform 0.15s ease;
+}
+
+details.show-meta[open] > summary::after {
+  transform: rotate(90deg);
 }
 
 audio,

--- a/home_stream/static/style.css
+++ b/home_stream/static/style.css
@@ -21,14 +21,14 @@ ul.files li {
   padding: 0.2rem 0;
 }
 
-/* Title from .nfo shown as the primary line above the filename */
+/* Title from .nfo shown as the primary line, alongside the action buttons */
 .file-title {
-  display: block;
   cursor: default;
 }
 
-/* Filename demoted to a muted reference line when a title is shown */
+/* Metadata + filename shown as a muted reference line below the buttons */
 .file-name {
+  display: block;
   font-size: 0.85rem;
   color: var(--pico-muted-color);
 }

--- a/home_stream/static/style.css
+++ b/home_stream/static/style.css
@@ -21,6 +21,20 @@ ul.files li {
   padding: 0.2rem 0;
 }
 
+/* Secondary metadata line under a file row (from .nfo sidecars) */
+.file-meta {
+  display: block;
+  font-size: 0.85rem;
+  color: var(--pico-muted-color);
+  cursor: default;
+}
+
+/* Folder-level show metadata header (from tvshow.nfo) */
+.show-meta {
+  color: var(--pico-muted-color);
+  cursor: default;
+}
+
 audio,
 video {
   width: 800px;

--- a/home_stream/templates/browse.html
+++ b/home_stream/templates/browse.html
@@ -1,6 +1,13 @@
 {%- extends "base.html" %}
 
 {%- block content %}
+{%- if show_metadata %}
+<p class="show-meta"{% if show_metadata.plot %} title="{{ show_metadata.plot }}"{% endif %}>
+  {%- if show_metadata.title %}<strong>{{ show_metadata.title }}</strong>{% endif %}
+  {%- if show_metadata.year %} ({{ show_metadata.year }}){% endif %}
+  {%- if show_metadata.rating %} ★{{ show_metadata.rating }}{% endif %}
+</p>
+{%- endif %}
 {%- if folders %}
 <h2>Folders</h2>
 <ul>
@@ -20,6 +27,13 @@
     <button onclick="copyToClipboard('{{ file.stream_url }}', this)">
       ▶️ Copy Stream URL
     </button>
+    {%- if file.metadata %}
+    <span class="file-meta"{% if file.metadata.plot %} title="{{ file.metadata.plot }}"{% endif %}>
+      {%- if file.metadata.title %}{{ file.metadata.title }}{% endif %}
+      {%- if file.metadata.year %} ({{ file.metadata.year }}){% endif %}
+      {%- if file.metadata.rating %} ★{{ file.metadata.rating }}{% endif %}
+    </span>
+    {%- endif %}
   </li>
   {%- endfor %}
 </ul>

--- a/home_stream/templates/browse.html
+++ b/home_stream/templates/browse.html
@@ -2,11 +2,19 @@
 
 {%- block content %}
 {%- if show_metadata %}
-<p class="show-meta"{% if show_metadata.plot %} title="{{ show_metadata.plot }}"{% endif %}>
+{%- set show_line %}
   {%- if show_metadata.title %}<strong>{{ show_metadata.title }}</strong>{% endif %}
   {%- if show_metadata.year %} ({{ show_metadata.year }}){% endif %}
   {%- if show_metadata.rating %} ★{{ show_metadata.rating }}{% endif %}
-</p>
+{%- endset %}
+{%- if show_metadata.plot %}
+<details class="show-meta">
+  <summary>{{ show_line }}</summary>
+  <p class="file-plot">{{ show_metadata.plot }}</p>
+</details>
+{%- else %}
+<p class="show-meta">{{ show_line }}</p>
+{%- endif %}
 {%- endif %}
 {%- if folders %}
 <h2>Folders</h2>
@@ -22,19 +30,26 @@
   {%- for file in files %}
   <li>
     {%- if file.metadata and file.metadata.title %}
-    <span class="file-title"{% if file.metadata.plot %} title="{{ file.metadata.plot }}"{% endif %}>
-      {{ file.metadata.title }}
-    </span> —
+    <span class="file-title">{{ file.metadata.title }}</span> —
     <a href="{{ file.stream_url }}" target="_blank"><button>💾 Download</button></a>
     <a href="{{ url_for('play', subpath=file.slug_path) }}"><button>🎬 Play</button></a>
     <button onclick="copyToClipboard('{{ file.stream_url }}', this)">
       🔗 Copy URL
     </button>
-    <span class="file-name">
+    {%- set meta_line %}
       {%- if file.metadata.episode_marker %}{{ file.metadata.episode_marker }} - {% endif %}
       {%- if file.metadata.year %}{{ file.metadata.year }} - {% endif %}
       {%- if file.metadata.rating %}★{{ file.metadata.rating }} - {% endif %}
-      {{- file.name }}</span>
+      {{- file.name }}
+    {%- endset %}
+    {%- if file.metadata.plot %}
+    <details class="file-details">
+      <summary class="file-name">{{ meta_line }}</summary>
+      <p class="file-plot">{{ file.metadata.plot }}</p>
+    </details>
+    {%- else %}
+    <span class="file-name">{{ meta_line }}</span>
+    {%- endif %}
     {%- else %}
     {{ file.name }} —
     <a href="{{ file.stream_url }}" target="_blank"><button>💾 Download</button></a>

--- a/home_stream/templates/browse.html
+++ b/home_stream/templates/browse.html
@@ -23,9 +23,9 @@
   <li>
     {{ file.name }} —
     <a href="{{ file.stream_url }}" target="_blank"><button>💾 Download</button></a>
-    <a href="{{ url_for('play', subpath=file.slug_path) }}"><button>🎬 Play in browser</button></a>
+    <a href="{{ url_for('play', subpath=file.slug_path) }}"><button>🎬 Play</button></a>
     <button onclick="copyToClipboard('{{ file.stream_url }}', this)">
-      ▶️ Copy Stream URL
+      🔗 Copy URL
     </button>
     {%- if file.metadata %}
     <span class="file-meta"{% if file.metadata.plot %} title="{{ file.metadata.plot }}"{% endif %}>

--- a/home_stream/templates/browse.html
+++ b/home_stream/templates/browse.html
@@ -24,20 +24,25 @@
     {%- if file.metadata and file.metadata.title %}
     <span class="file-title"{% if file.metadata.plot %} title="{{ file.metadata.plot }}"{% endif %}>
       {{ file.metadata.title }}
-    </span>
-    <span class="file-name">
-      {%- if file.metadata.episode_marker %}{{ file.metadata.episode_marker }} - {% endif %}
-      {%- if file.metadata.year %}{{ file.metadata.year }} - {% endif %}
-      {%- if file.metadata.rating %}★{{ file.metadata.rating }} - {% endif %}
-      {{- file.name }}</span> —
-    {%- else %}
-    {{ file.name }} —
-    {%- endif %}
+    </span> —
     <a href="{{ file.stream_url }}" target="_blank"><button>💾 Download</button></a>
     <a href="{{ url_for('play', subpath=file.slug_path) }}"><button>🎬 Play</button></a>
     <button onclick="copyToClipboard('{{ file.stream_url }}', this)">
       🔗 Copy URL
     </button>
+    <span class="file-name">
+      {%- if file.metadata.episode_marker %}{{ file.metadata.episode_marker }} - {% endif %}
+      {%- if file.metadata.year %}{{ file.metadata.year }} - {% endif %}
+      {%- if file.metadata.rating %}★{{ file.metadata.rating }} - {% endif %}
+      {{- file.name }}</span>
+    {%- else %}
+    {{ file.name }} —
+    <a href="{{ file.stream_url }}" target="_blank"><button>💾 Download</button></a>
+    <a href="{{ url_for('play', subpath=file.slug_path) }}"><button>🎬 Play</button></a>
+    <button onclick="copyToClipboard('{{ file.stream_url }}', this)">
+      🔗 Copy URL
+    </button>
+    {%- endif %}
   </li>
   {%- endfor %}
 </ul>

--- a/home_stream/templates/browse.html
+++ b/home_stream/templates/browse.html
@@ -21,19 +21,21 @@
 <ul class="files">
   {%- for file in files %}
   <li>
+    {%- if file.metadata and file.metadata.title %}
+    <span class="file-title"{% if file.metadata.plot %} title="{{ file.metadata.plot }}"{% endif %}>
+      {{ file.metadata.title }}
+      {%- if file.metadata.year %} ({{ file.metadata.year }}){% endif %}
+      {%- if file.metadata.rating %} ★{{ file.metadata.rating }}{% endif %}
+    </span>
+    <span class="file-name">{{ file.name }}</span> —
+    {%- else %}
     {{ file.name }} —
+    {%- endif %}
     <a href="{{ file.stream_url }}" target="_blank"><button>💾 Download</button></a>
     <a href="{{ url_for('play', subpath=file.slug_path) }}"><button>🎬 Play</button></a>
     <button onclick="copyToClipboard('{{ file.stream_url }}', this)">
       🔗 Copy URL
     </button>
-    {%- if file.metadata %}
-    <span class="file-meta"{% if file.metadata.plot %} title="{{ file.metadata.plot }}"{% endif %}>
-      {%- if file.metadata.title %}{{ file.metadata.title }}{% endif %}
-      {%- if file.metadata.year %} ({{ file.metadata.year }}){% endif %}
-      {%- if file.metadata.rating %} ★{{ file.metadata.rating }}{% endif %}
-    </span>
-    {%- endif %}
   </li>
   {%- endfor %}
 </ul>

--- a/home_stream/templates/browse.html
+++ b/home_stream/templates/browse.html
@@ -24,10 +24,12 @@
     {%- if file.metadata and file.metadata.title %}
     <span class="file-title"{% if file.metadata.plot %} title="{{ file.metadata.plot }}"{% endif %}>
       {{ file.metadata.title }}
-      {%- if file.metadata.year %} ({{ file.metadata.year }}){% endif %}
-      {%- if file.metadata.rating %} ★{{ file.metadata.rating }}{% endif %}
     </span>
-    <span class="file-name">{{ file.name }}</span> —
+    <span class="file-name">
+      {%- if file.metadata.episode_marker %}{{ file.metadata.episode_marker }} - {% endif %}
+      {%- if file.metadata.year %}{{ file.metadata.year }} - {% endif %}
+      {%- if file.metadata.rating %}★{{ file.metadata.rating }} - {% endif %}
+      {{- file.name }}</span> —
     {%- else %}
     {{ file.name }} —
     {%- endif %}

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -505,8 +505,32 @@ def test_read_nfo_metadata_episode(tmp_path) -> None:
     meta = read_nfo_metadata(str(media))
     assert meta["title"] == "Br\u00fcder"
     assert meta["plot"].startswith("Toni Hamady")
+    assert meta["episode_marker"] == "S01E01"
     assert "rating" not in meta  # 0.0 dropped
     assert "year" not in meta
+
+
+def test_read_nfo_metadata_no_marker_without_season(tmp_path) -> None:
+    """A movie .nfo (no season/episode tags) has no episode marker."""
+    media = tmp_path / "movie.mkv"
+    media.write_bytes(b"x")
+    (tmp_path / "movie.nfo").write_text(
+        "<movie><title>Der Pate</title><year>1972</year></movie>", encoding="utf-8"
+    )
+    meta = read_nfo_metadata(str(media))
+    assert meta["title"] == "Der Pate"
+    assert "episode_marker" not in meta
+
+
+def test_read_nfo_metadata_ignores_negative_season(tmp_path) -> None:
+    """Placeholder -1 season/episode does not produce a marker."""
+    media = tmp_path / "ep.mkv"
+    media.write_bytes(b"x")
+    (tmp_path / "ep.nfo").write_text(
+        "<episodedetails><title>X</title><season>-1</season><episode>-1</episode></episodedetails>",
+        encoding="utf-8",
+    )
+    assert "episode_marker" not in read_nfo_metadata(str(media))
 
 
 def test_read_nfo_metadata_missing(tmp_path) -> None:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -20,6 +20,8 @@ from home_stream.helpers import (
     get_version_info,
     load_config,
     prepare_path_context,
+    read_nfo_metadata,
+    read_tvshow_metadata,
     sanitize_filename,
     secure_path,
     slugify,
@@ -466,3 +468,94 @@ def test_prepare_path_context_with_surrogate_in_path() -> None:
     # The display name must not contain surrogates (would crash template rendering)
     assert "\udc96" not in context["current_name"]
     assert "\ufffd" in context["current_name"]
+
+
+# --- .nfo metadata reader tests ---
+
+EPISODE_NFO = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--created by tinyMediaManager-->
+<episodedetails>
+  <title>Br\u00fcder</title>
+  <originaltitle/>
+  <showtitle>4 Blocks</showtitle>
+  <season>1</season>
+  <episode>1</episode>
+  <rating>0.0</rating>
+  <votes>0</votes>
+  <plot>Toni Hamady plant den Ausstieg.</plot>
+</episodedetails>
+"""
+
+TVSHOW_NFO = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<tvshow>
+  <title>4 Blocks</title>
+  <year>2017</year>
+  <rating>8.1</rating>
+  <plot>Eine Geschichte um Freundschaft und Familie.</plot>
+</tvshow>
+"""
+
+
+def test_read_nfo_metadata_episode(tmp_path) -> None:
+    """Episode .nfo yields title and plot; placeholder rating 0.0 is dropped."""
+    media = tmp_path / "4.blocks.s01e01.mkv"
+    media.write_bytes(b"x")
+    (tmp_path / "4.blocks.s01e01.nfo").write_text(EPISODE_NFO, encoding="utf-8")
+
+    meta = read_nfo_metadata(str(media))
+    assert meta["title"] == "Br\u00fcder"
+    assert meta["plot"].startswith("Toni Hamady")
+    assert "rating" not in meta  # 0.0 dropped
+    assert "year" not in meta
+
+
+def test_read_nfo_metadata_missing(tmp_path) -> None:
+    """No sibling .nfo returns an empty dict."""
+    media = tmp_path / "movie.mkv"
+    media.write_bytes(b"x")
+    assert read_nfo_metadata(str(media)) == {}
+
+
+def test_read_nfo_metadata_malformed(tmp_path) -> None:
+    """Malformed XML returns an empty dict rather than raising."""
+    media = tmp_path / "movie.mkv"
+    media.write_bytes(b"x")
+    (tmp_path / "movie.nfo").write_text("<tvshow><title>broken", encoding="utf-8")
+    assert read_nfo_metadata(str(media)) == {}
+
+
+def test_read_nfo_metadata_rejects_doctype(tmp_path) -> None:
+    """A .nfo declaring a DOCTYPE/ENTITY (XML-bomb vector) is refused."""
+    bomb = (
+        '<?xml version="1.0"?>\n'
+        '<!DOCTYPE lolz [<!ENTITY lol "lol">]>\n'
+        "<tvshow><title>&lol;</title></tvshow>"
+    )
+    media = tmp_path / "movie.mkv"
+    media.write_bytes(b"x")
+    (tmp_path / "movie.nfo").write_text(bomb, encoding="utf-8")
+    assert read_nfo_metadata(str(media)) == {}
+
+
+def test_read_nfo_metadata_oversized(tmp_path) -> None:
+    """A .nfo larger than the size cap is not parsed."""
+    media = tmp_path / "movie.mkv"
+    media.write_bytes(b"x")
+    big = "<tvshow><title>x</title></tvshow>" + ("<!-- pad -->" * 100000)
+    (tmp_path / "movie.nfo").write_text(big, encoding="utf-8")
+    assert read_nfo_metadata(str(media)) == {}
+
+
+def test_read_tvshow_metadata(tmp_path) -> None:
+    """tvshow.nfo yields title, year, rating and plot."""
+    (tmp_path / "tvshow.nfo").write_text(TVSHOW_NFO, encoding="utf-8")
+    meta = read_tvshow_metadata(str(tmp_path))
+    assert meta["title"] == "4 Blocks"
+    assert meta["year"] == "2017"
+    assert meta["rating"] == "8.1"
+    assert meta["plot"].startswith("Eine Geschichte")
+
+
+def test_read_tvshow_metadata_missing(tmp_path) -> None:
+    """Folder without tvshow.nfo returns an empty dict."""
+    assert read_tvshow_metadata(str(tmp_path)) == {}

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -522,6 +522,35 @@ def test_read_nfo_metadata_no_marker_without_season(tmp_path) -> None:
     assert "episode_marker" not in meta
 
 
+def test_read_nfo_metadata_nested_movie_rating(tmp_path) -> None:
+    """Movie .nfo with a nested <ratings> block yields the default rating value."""
+    media = tmp_path / "movie.mkv"
+    media.write_bytes(b"x")
+    (tmp_path / "movie.nfo").write_text(
+        "<movie><title>Der Pate</title>"
+        '<ratings><rating default="true" max="10" name="imdb">'
+        "<value>7.3</value><votes>397384</votes></rating></ratings>"
+        "</movie>",
+        encoding="utf-8",
+    )
+    meta = read_nfo_metadata(str(media))
+    assert meta["rating"] == "7.3"
+
+
+def test_read_nfo_metadata_nested_rating_prefers_default(tmp_path) -> None:
+    """When multiple nested ratings exist, the one marked default wins."""
+    media = tmp_path / "movie.mkv"
+    media.write_bytes(b"x")
+    (tmp_path / "movie.nfo").write_text(
+        "<movie><title>X</title><ratings>"
+        '<rating name="themoviedb"><value>6.1</value></rating>'
+        '<rating default="true" name="imdb"><value>7.3</value></rating>'
+        "</ratings></movie>",
+        encoding="utf-8",
+    )
+    assert read_nfo_metadata(str(media))["rating"] == "7.3"
+
+
 def test_read_nfo_metadata_ignores_negative_season(tmp_path) -> None:
     """Placeholder -1 season/episode does not produce a marker."""
     media = tmp_path / "ep.mkv"

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -302,3 +302,78 @@ def test_play_folder_with_multiple_files(client, app, media_file_slugs, stream_t
             found_stream_url = True
 
     assert found_stream_url, "Expected stream URL not found in any playlist item"
+
+
+# --- .nfo metadata rendering tests ---
+
+
+def test_browse_shows_nfo_title(client, app, media_file) -> None:
+    """A sibling .nfo title is rendered as a secondary line in the browse view."""
+    nfo_path = media_file.rsplit(".", 1)[0] + ".nfo"
+    with open(nfo_path, "w", encoding="utf-8") as f:
+        f.write(
+            '<?xml version="1.0"?>\n'
+            "<episodedetails><title>Real Episode Title</title>"
+            "<rating>0.0</rating><plot>Some plot.</plot></episodedetails>"
+        )
+
+    with client.session_transaction() as sess:
+        login_session(sess, app)
+
+    response = client.get("/browse/test/with_spaces/")
+    soup = BeautifulSoup(response.data, "html.parser")
+    meta = soup.find("span", class_="file-meta")
+    assert meta is not None
+    assert "Real Episode Title" in meta.get_text()
+    # Placeholder rating 0.0 must not render
+    assert "0.0" not in meta.get_text()
+    # Plot is exposed as a hover tooltip
+    assert meta.get("title") == "Some plot."
+
+
+def test_browse_shows_tvshow_header(client, app, media_file) -> None:
+    """A tvshow.nfo in the folder renders a show metadata header."""
+    folder = dirname(media_file)
+    with open(f"{folder}/tvshow.nfo", "w", encoding="utf-8") as f:
+        f.write(
+            '<?xml version="1.0"?>\n'
+            "<tvshow><title>My Show</title><year>2017</year>"
+            "<rating>8.1</rating></tvshow>"
+        )
+
+    with client.session_transaction() as sess:
+        login_session(sess, app)
+
+    response = client.get("/browse/test/with_spaces/")
+    soup = BeautifulSoup(response.data, "html.parser")
+    header = soup.find("p", class_="show-meta")
+    assert header is not None
+    text = header.get_text()
+    assert "My Show" in text
+    assert "2017" in text
+    assert "8.1" in text
+
+
+def test_browse_no_nfo_no_meta(client, app, media_file) -> None:
+    """Without .nfo files, no metadata elements are rendered."""
+    with client.session_transaction() as sess:
+        login_session(sess, app)
+
+    response = client.get("/browse/test/with_spaces/")
+    soup = BeautifulSoup(response.data, "html.parser")
+    assert soup.find("span", class_="file-meta") is None
+    assert soup.find("p", class_="show-meta") is None
+
+
+def test_browse_nfo_disabled(client, app, media_file) -> None:
+    """With the toggle off, .nfo metadata is not read or rendered."""
+    app.config["SHOW_NFO_METADATA"] = False
+    nfo_path = media_file.rsplit(".", 1)[0] + ".nfo"
+    with open(nfo_path, "w", encoding="utf-8") as f:
+        f.write("<episodedetails><title>Hidden</title></episodedetails>")
+
+    with client.session_transaction() as sess:
+        login_session(sess, app)
+
+    response = client.get("/browse/test/with_spaces/")
+    assert b"Hidden" not in response.data

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -327,14 +327,19 @@ def test_browse_shows_nfo_title(client, app, media_file) -> None:
     title = soup.find("span", class_="file-title")
     assert title is not None
     assert title.get_text(strip=True) == "Real Episode Title"
-    # Plot is exposed as a hover tooltip on the title
-    assert title.get("title") == "Some plot."
-    # Secondary line: SxxExx - year - rating - filename, in that order
-    name_line = soup.find("span", class_="file-name")
-    assert name_line is not None
-    text = " ".join(name_line.get_text().split())
+    # Plot is shown in a collapsible <details>, with the metadata line as the summary
+    details = soup.find("details", class_="file-details")
+    assert details is not None
+    summary = details.find("summary", class_="file-name")
+    assert summary is not None
+    # Secondary (summary) line: SxxExx - year - rating - filename, in that order
+    text = " ".join(summary.get_text().split())
     assert text.startswith("S02E04 - 2018 - \u26057.5 - ")
     assert text.endswith(".mp3")
+    # Plot is real DOM text (not a tooltip), inside the details
+    plot = details.find("p", class_="file-plot")
+    assert plot is not None
+    assert plot.get_text(strip=True) == "Some plot."
 
 
 def test_browse_shows_tvshow_header(client, app, media_file) -> None:

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -314,7 +314,9 @@ def test_browse_shows_nfo_title(client, app, media_file) -> None:
         f.write(
             '<?xml version="1.0"?>\n'
             "<episodedetails><title>Real Episode Title</title>"
-            "<rating>0.0</rating><plot>Some plot.</plot></episodedetails>"
+            "<season>2</season><episode>4</episode>"
+            "<year>2018</year><rating>7.5</rating>"
+            "<plot>Some plot.</plot></episodedetails>"
         )
 
     with client.session_transaction() as sess:
@@ -324,13 +326,15 @@ def test_browse_shows_nfo_title(client, app, media_file) -> None:
     soup = BeautifulSoup(response.data, "html.parser")
     title = soup.find("span", class_="file-title")
     assert title is not None
-    assert "Real Episode Title" in title.get_text()
-    # Placeholder rating 0.0 must not render
-    assert "0.0" not in title.get_text()
-    # Plot is exposed as a hover tooltip
+    assert title.get_text(strip=True) == "Real Episode Title"
+    # Plot is exposed as a hover tooltip on the title
     assert title.get("title") == "Some plot."
-    # The filename is demoted to a muted reference line
-    assert soup.find("span", class_="file-name") is not None
+    # Secondary line: SxxExx - year - rating - filename, in that order
+    name_line = soup.find("span", class_="file-name")
+    assert name_line is not None
+    text = " ".join(name_line.get_text().split())
+    assert text.startswith("S02E04 - 2018 - \u26057.5 - ")
+    assert text.endswith(".mp3")
 
 
 def test_browse_shows_tvshow_header(client, app, media_file) -> None:

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -121,8 +121,8 @@ def test_browse_stream_url_copy_button(client, app, media_file_slugs, stream_tok
 
     response = client.get("/browse/test/with_spaces/")
     soup = BeautifulSoup(response.data, "html.parser")
-    buttons = soup.find_all("button", string=lambda text: text and "Copy Stream URL" in text)
-    assert buttons, "No Copy Stream URL button found"
+    buttons = soup.find_all("button", string=lambda text: text and "Copy URL" in text)
+    assert buttons, "No Copy URL button found"
 
     button = buttons[0]
     onclick = button.get("onclick")
@@ -308,7 +308,7 @@ def test_play_folder_with_multiple_files(client, app, media_file_slugs, stream_t
 
 
 def test_browse_shows_nfo_title(client, app, media_file) -> None:
-    """A sibling .nfo title is rendered as a secondary line in the browse view."""
+    """A sibling .nfo title is rendered as the primary line, filename demoted below."""
     nfo_path = media_file.rsplit(".", 1)[0] + ".nfo"
     with open(nfo_path, "w", encoding="utf-8") as f:
         f.write(
@@ -322,13 +322,15 @@ def test_browse_shows_nfo_title(client, app, media_file) -> None:
 
     response = client.get("/browse/test/with_spaces/")
     soup = BeautifulSoup(response.data, "html.parser")
-    meta = soup.find("span", class_="file-meta")
-    assert meta is not None
-    assert "Real Episode Title" in meta.get_text()
+    title = soup.find("span", class_="file-title")
+    assert title is not None
+    assert "Real Episode Title" in title.get_text()
     # Placeholder rating 0.0 must not render
-    assert "0.0" not in meta.get_text()
+    assert "0.0" not in title.get_text()
     # Plot is exposed as a hover tooltip
-    assert meta.get("title") == "Some plot."
+    assert title.get("title") == "Some plot."
+    # The filename is demoted to a muted reference line
+    assert soup.find("span", class_="file-name") is not None
 
 
 def test_browse_shows_tvshow_header(client, app, media_file) -> None:
@@ -361,7 +363,8 @@ def test_browse_no_nfo_no_meta(client, app, media_file) -> None:
 
     response = client.get("/browse/test/with_spaces/")
     soup = BeautifulSoup(response.data, "html.parser")
-    assert soup.find("span", class_="file-meta") is None
+    assert soup.find("span", class_="file-title") is None
+    assert soup.find("span", class_="file-name") is None
     assert soup.find("p", class_="show-meta") is None
 
 


### PR DESCRIPTION
Shows metadata for video files, using the Kodi .nfo files.

Partly fixes #68, with the focus on video. ID3 (audio) may follow later.